### PR TITLE
redesign of how the index is processed

### DIFF
--- a/src/bucketcolumn.rs
+++ b/src/bucketcolumn.rs
@@ -8,6 +8,7 @@ pub struct BucketColumn {
     //TO-DO: Make data Vec<Vec<usize>> and move worker count
     pub(crate) data: Vec<usize>,
     pub(crate) buckets_count: usize,
+    pub(crate) hash: HashColumn,
 }
 
 impl Deref for BucketColumn {
@@ -18,7 +19,7 @@ impl Deref for BucketColumn {
 }
 
 impl BucketColumn {
-    pub fn from_hash(hash: &HashColumn, bucket_bits: u32) -> BucketColumn {
+    pub fn from_hash(hash: HashColumn, bucket_bits: u32) -> BucketColumn {
         let buckets_count = 2usize.pow(bucket_bits);
         assert!((buckets_count as u64) < (u64::MAX) / 2, "Too many buckets");
         BucketColumn {
@@ -28,6 +29,7 @@ impl BucketColumn {
                 .map(|h| (h % (2 * buckets_count as u64)) as usize)
                 .collect(),
             buckets_count,
+            hash,
         }
     }
 }
@@ -37,6 +39,7 @@ pub struct BucketColumnPartitioned {
     //TO-DO: Make data Vec<Vec<usize>> and move worker count
     pub(crate) data: Vec<Vec<usize>>, //buckets_count
     pub(crate) buckets_count: usize,
+    pub(crate) hash: HashColumnPartitioned,
 }
 
 impl Deref for BucketColumnPartitioned {
@@ -47,7 +50,7 @@ impl Deref for BucketColumnPartitioned {
 }
 
 impl BucketColumnPartitioned {
-    pub fn from_hash(hash: &HashColumnPartitioned, bucket_bits: u32) -> BucketColumnPartitioned {
+    pub fn from_hash(hash: HashColumnPartitioned, bucket_bits: u32) -> BucketColumnPartitioned {
         let buckets_count = 2usize.pow(bucket_bits);
         assert!((buckets_count as u64) < (u64::MAX) / 2, "Too many buckets");
         BucketColumnPartitioned {
@@ -61,6 +64,7 @@ impl BucketColumnPartitioned {
                 })
                 .collect(),
             buckets_count,
+            hash,
         }
     }
 }
@@ -74,6 +78,7 @@ pub struct BucketsSizeMap {
     pub(crate) bucket_column: Vec<usize>,
     pub(crate) offsets: Vec<Vec<usize>>,
     pub(crate) bucket_sizes: Vec<usize>,
+    pub(crate) hash: HashColumn,
 }
 
 impl Deref for BucketsSizeMap {
@@ -122,6 +127,7 @@ impl BucketsSizeMap {
             bucket_column: bc.data,
             offsets,
             bucket_sizes,
+            hash: bc.hash,
         }
     }
 }
@@ -135,6 +141,7 @@ pub struct BucketsSizeMapPartitioned {
     pub(crate) buckets_count: usize,
     pub(crate) offsets: Vec<Vec<usize>>,
     pub(crate) bucket_sizes: Vec<usize>,
+    pub(crate) hash: HashColumnPartitioned,
 }
 
 impl Deref for BucketsSizeMapPartitioned {
@@ -182,6 +189,7 @@ impl BucketsSizeMapPartitioned {
             buckets_count: bc.buckets_count,
             offsets,
             bucket_sizes,
+            hash: bc.hash,
         }
     }
 }

--- a/src/columnflatten.rs
+++ b/src/columnflatten.rs
@@ -1,0 +1,13 @@
+use crate::bucketcolumn::*;
+use crate::columnu8::*;
+use crate::hashcolumn::*;
+use rayon::prelude::*;
+use std::cell::UnsafeCell;
+use std::hash::{BuildHasher, Hash, Hasher};
+use std::mem::{self, MaybeUninit};
+
+pub trait ColumnFlatten<T> {
+    fn flatten(self) -> Vec<T>
+    where
+        T: Send + Sync;
+}

--- a/src/columnu8.rs
+++ b/src/columnu8.rs
@@ -15,10 +15,14 @@ pub(crate) struct MaybeColumnU8 {
 
 #[derive(Debug, PartialEq)]
 pub enum PartitionedColumn<T> {
-    FixedLenType(Vec<(Vec<T>, Option<Vec<Option<usize>>>)>),
-    VariableLenType(Vec<(ColumnU8, Option<Vec<Option<usize>>>)>),
+    FixedLenType(Vec<Vec<T>>),
+    VariableLenType(Vec<ColumnU8>),
 }
 
 pub struct StringVec {
     pub strvec: Vec<String>,
 }
+
+pub type ColumnIndex = Option<Vec<Option<usize>>>;
+
+pub type ColumnIndexPartitioned = Vec<ColumnIndex>;

--- a/src/hashcolumn.rs
+++ b/src/hashcolumn.rs
@@ -1,9 +1,10 @@
+use crate::columnu8::*;
 use std::ops::Deref;
 
 #[derive(Debug, PartialEq)]
 pub struct HashColumn {
     pub(crate) data: Vec<u64>,
-    pub(crate) index: Option<Vec<Option<usize>>>,
+    pub(crate) index: ColumnIndex,
 }
 
 impl Deref for HashColumn {
@@ -15,6 +16,7 @@ impl Deref for HashColumn {
 
 pub struct HashColumnPartitioned {
     pub(crate) data: Vec<Vec<u64>>,
+    pub(crate) index: ColumnIndexPartitioned,
 }
 
 impl<'a> Deref for HashColumnPartitioned {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ mod tests {
             data: vec![1, 2, 4, 6, 8, 10],
             index: None,
         };
-        let b = BucketColumn::from_hash(&hash, 2);
+        let b = BucketColumn::from_hash(hash, 2);
         assert_eq!(*b, vec![1, 2, 4, 6, 0, 2]);
     }
 
@@ -139,7 +139,7 @@ mod tests {
             data: vec![1, 2, 4, 6, 8, 10],
             index: None,
         };
-        let _b = BucketColumn::from_hash(&hash, 63);
+        let _b = BucketColumn::from_hash(hash, 63);
     }
 
     #[test]
@@ -148,7 +148,7 @@ mod tests {
             data: vec![1, 2, 4, 6, 8, 10],
             index: None,
         };
-        let b = BucketColumn::from_hash(&hash, 2);
+        let b = BucketColumn::from_hash(hash, 2);
         assert_eq!(*b, vec![1, 2, 4, 6, 0, 2]);
         let bmap = BucketsSizeMap::from_bucket_column(b, 2);
         assert_eq!(*bmap, vec![vec![0, 1, 1, 0], vec![1, 1, 0, 1]]);
@@ -161,7 +161,7 @@ mod tests {
             data: vec![1, 2, 4, 6, 8, 10],
             index: None,
         };
-        let b = BucketColumn::from_hash(&hash, 2);
+        let b = BucketColumn::from_hash(hash, 2);
         assert_eq!(*b, vec![1, 2, 4, 6, 0, 2]);
         let bmap = BucketsSizeMap::from_bucket_column(b, 1);
         assert_eq!(*bmap, vec![vec![1, 2, 1, 1]]);
@@ -174,7 +174,7 @@ mod tests {
             data: vec![1, 2, 4, 6, 8, 10],
             index: None,
         };
-        let b = BucketColumn::from_hash(&hash, 2);
+        let b = BucketColumn::from_hash(hash, 2);
         assert_eq!(*b, vec![1, 2, 4, 6, 0, 2]);
         let bmap = BucketsSizeMap::from_bucket_column(b, 2);
         assert_eq!(*bmap, vec![vec![0, 1, 1, 0], vec![1, 1, 0, 1]]);
@@ -188,22 +188,18 @@ mod tests {
             data: vec![1, 2, 4, 6, 8, 10],
             index: None,
         };
-        let b = BucketColumn::from_hash(&hash, 2);
+        let data = vec![1, 2, 4, 6, 8, 10];
+        let b = BucketColumn::from_hash(hash, 2);
         assert_eq!(*b, vec![1, 2, 4, 6, 0, 2]);
         let bmap = BucketsSizeMap::from_bucket_column(b, 2);
         assert_eq!(*bmap, vec![vec![0, 1, 1, 0], vec![1, 1, 0, 1]]);
         assert_eq!(bmap.offsets, vec![vec![0, 0, 0, 0], vec![0, 1, 1, 0]]);
         assert_eq!(bmap.bucket_sizes, vec![1, 2, 1, 1]);
 
-        let part = hash.partition_column(&bmap, &None);
+        let part = data.partition_column(&bmap);
         assert_eq!(
             part,
-            PartitionedColumn::FixedLenType(vec![
-                (vec![8], None),
-                (vec![2, 10], None),
-                (vec![4], None),
-                (vec![6], None)
-            ])
+            PartitionedColumn::FixedLenType(vec![vec![8], vec![2, 10], vec![4], vec![6]])
         );
     }
 
@@ -222,48 +218,36 @@ mod tests {
             "fff".to_string(),
         ];
         let strvec = StringVec { strvec };
-        let b = BucketColumn::from_hash(&hash, 2);
+        let b = BucketColumn::from_hash(hash, 2);
         assert_eq!(*b, vec![1, 2, 4, 6, 0, 2]);
         let bmap = BucketsSizeMap::from_bucket_column(b, 2);
         assert_eq!(*bmap, vec![vec![0, 1, 1, 0], vec![1, 1, 0, 1]]);
         assert_eq!(bmap.offsets, vec![vec![0, 0, 0, 0], vec![0, 1, 1, 0]]);
         assert_eq!(bmap.bucket_sizes, vec![1, 2, 1, 1]);
 
-        let part = strvec.partition_column(&bmap, &None);
+        let part = strvec.partition_column(&bmap);
 
         let expected_result = PartitionedColumn::<String>::VariableLenType(vec![
-            (
-                ColumnU8 {
-                    data: vec![101, 101],
-                    start_pos: vec![0],
-                    len: vec![2],
-                },
-                None,
-            ),
-            (
-                ColumnU8 {
-                    data: vec![98, 98, 102, 102, 102],
-                    start_pos: vec![0, 2],
-                    len: vec![2, 3],
-                },
-                None,
-            ),
-            (
-                ColumnU8 {
-                    data: vec![99, 99],
-                    start_pos: vec![0],
-                    len: vec![2],
-                },
-                None,
-            ),
-            (
-                ColumnU8 {
-                    data: vec![100, 100],
-                    start_pos: vec![0],
-                    len: vec![2],
-                },
-                None,
-            ),
+            ColumnU8 {
+                data: vec![101, 101],
+                start_pos: vec![0],
+                len: vec![2],
+            },
+            ColumnU8 {
+                data: vec![98, 98, 102, 102, 102],
+                start_pos: vec![0, 2],
+                len: vec![2, 3],
+            },
+            ColumnU8 {
+                data: vec![99, 99],
+                start_pos: vec![0],
+                len: vec![2],
+            },
+            ColumnU8 {
+                data: vec![100, 100],
+                start_pos: vec![0],
+                len: vec![2],
+            },
         ]);
         assert_eq!(part, expected_result);
     }
@@ -277,47 +261,46 @@ mod tests {
             index: Some(vec![Some(0), Some(1), Some(2), Some(3), Some(4), Some(5)]),
         };
 
-        let b = BucketColumn::from_hash(&hash, 2);
+        let b = BucketColumn::from_hash(hash, 2);
         let bmap = BucketsSizeMap::from_bucket_column(b, 2);
-        let part = data.partition_column(&bmap, &None);
+        let part = data.partition_column(&bmap);
 
         let hash = HashColumn { data, index: None };
 
-        let hash = hash.data.partition_column(&bmap, &None);
+        let hash = hash.data.partition_column(&bmap);
         let hash = if let PartitionedColumn::FixedLenType(hash_inner) = hash {
             hash_inner
         } else {
             panic!()
         };
-        let hash = hash.into_iter().map(|(data, _index)| data).collect();
+        let index = hash.iter().map(|_| None).collect();
+        let hash: HashColumnPartitioned = HashColumnPartitioned { data: hash, index };
 
-        let hash: HashColumnPartitioned = HashColumnPartitioned { data: hash };
+        let b = BucketColumnPartitioned::from_hash(hash, 2);
+        let mut bmap = BucketsSizeMapPartitioned::from_bucket_column(b);
 
-        let b = BucketColumnPartitioned::from_hash(&hash, 2);
-        let bmap = BucketsSizeMapPartitioned::from_bucket_column(b);
-
-        let mut part = if let PartitionedColumn::FixedLenType(part_inner) = part {
-            part_inner
-        } else {
-            panic!()
-        };
-
-        part.iter_mut()
+        let new_index = bmap
+            .bucket_column
+            .iter()
             .enumerate()
-            .filter(|(i, _)| i & 2 == 0)
-            .for_each(|(_, (v, index))| *index = Some((0..v.len()).map(Some).collect()));
+            .map(|(i, v)| {
+                if i & 2 == 0 {
+                    Some((0..v.len()).map(Some).collect())
+                } else {
+                    None
+                }
+            })
+            .collect();
 
-        let part = PartitionedColumn::FixedLenType(part);
+        bmap.hash.index = new_index;
+
+        println!("{:?}", part);
         let part = part.partition_column(&bmap);
+        println!("{:?}", part);
 
         assert_eq!(
             part,
-            PartitionedColumn::FixedLenType(vec![
-                (vec![8], None),
-                (vec![2, 10], None),
-                (vec![4], None),
-                (vec![6], None)
-            ])
+            PartitionedColumn::FixedLenType(vec![vec![8], vec![2, 10], vec![4], vec![6]])
         );
     }
     #[test]
@@ -337,25 +320,25 @@ mod tests {
             index: Some(vec![Some(0), Some(1), Some(2), Some(3), Some(4), Some(5)]),
         };
 
-        let b = BucketColumn::from_hash(&hash, 2);
+        let b = BucketColumn::from_hash(hash, 2);
         let bmap = BucketsSizeMap::from_bucket_column(b, 2);
-        let part = strvec.partition_column(&bmap, &None);
+        let part = strvec.partition_column(&bmap);
 
         let data: Vec<u64> = vec![1, 2, 4, 6, 8, 10];
         let hash = HashColumn { data, index: None };
 
-        let hash = hash.data.partition_column(&bmap, &None);
+        let hash = hash.data.partition_column(&bmap);
         let hash = if let PartitionedColumn::FixedLenType(hash_inner) = hash {
             hash_inner
         } else {
             panic!()
         };
-        let hash = hash.into_iter().map(|(data, _index)| data).collect();
 
-        let hash: HashColumnPartitioned = HashColumnPartitioned { data: hash };
+        let index = hash.iter().map(|_| None).collect();
+        let hash: HashColumnPartitioned = HashColumnPartitioned { data: hash, index };
 
-        let b = BucketColumnPartitioned::from_hash(&hash, 2);
-        let bmap = BucketsSizeMapPartitioned::from_bucket_column(b);
+        let b = BucketColumnPartitioned::from_hash(hash, 2);
+        let mut bmap = BucketsSizeMapPartitioned::from_bucket_column(b);
 
         let mut part = if let PartitionedColumn::VariableLenType(part_inner) = part {
             part_inner
@@ -363,49 +346,46 @@ mod tests {
             panic!()
         };
 
-        part.iter_mut()
+        let new_index = bmap
+            .bucket_column
+            .iter()
             .enumerate()
-            .filter(|(i, _)| i & 2 == 0)
-            .for_each(|(_, (v, index))| *index = Some((0..v.start_pos.len()).map(Some).collect()));
+            .map(|(i, v)| {
+                if i & 2 == 0 {
+                    Some((0..v.len()).map(Some).collect())
+                } else {
+                    None
+                }
+            })
+            .collect();
 
+        bmap.hash.index = new_index;
         let part = PartitionedColumn::VariableLenType(part);
 
         println!("{:?}", part);
         let part = part.partition_column(&bmap);
         println!("{:?}", part);
         let expected_result = PartitionedColumn::<String>::VariableLenType(vec![
-            (
-                ColumnU8 {
-                    data: vec![101, 101],
-                    start_pos: vec![0],
-                    len: vec![2],
-                },
-                None,
-            ),
-            (
-                ColumnU8 {
-                    data: vec![98, 98, 102, 102, 102],
-                    start_pos: vec![0, 2],
-                    len: vec![2, 3],
-                },
-                None,
-            ),
-            (
-                ColumnU8 {
-                    data: vec![99, 99],
-                    start_pos: vec![0],
-                    len: vec![2],
-                },
-                None,
-            ),
-            (
-                ColumnU8 {
-                    data: vec![100, 100],
-                    start_pos: vec![0],
-                    len: vec![2],
-                },
-                None,
-            ),
+            ColumnU8 {
+                data: vec![101, 101],
+                start_pos: vec![0],
+                len: vec![2],
+            },
+            ColumnU8 {
+                data: vec![98, 98, 102, 102, 102],
+                start_pos: vec![0, 2],
+                len: vec![2, 3],
+            },
+            ColumnU8 {
+                data: vec![99, 99],
+                start_pos: vec![0],
+                len: vec![2],
+            },
+            ColumnU8 {
+                data: vec![100, 100],
+                start_pos: vec![0],
+                len: vec![2],
+            },
         ]);
         assert_eq!(part, expected_result);
     }


### PR DESCRIPTION
Propagate the index of the column as a struct field as follows: Hash Column->Bucket Column->Bucket Size Map.

There is also a validation when adding a column to a hash, and when partitioning a column based on a bucket size map that indeed the index and the column structures are compatible. This prevents a soundness issue of applying an incorrectly sized Bucket Size Map, leading to undefined behavior.